### PR TITLE
If overshooting tops returns an empty string, strip trailing comma

### DIFF
--- a/NWCSAF2ADAGUC/RDT/nwcpy_rdt_to_geoJSON.py
+++ b/NWCSAF2ADAGUC/RDT/nwcpy_rdt_to_geoJSON.py
@@ -385,7 +385,11 @@ def rdtDataSetToJson(dataSet, conf, DecTime, fct='000'):
 
     # adding the overshooting tops
     if 'NumIdCellOT' in dataSet.variables:
-            text = text + plotOT(dataSet, conf)
+            text_OT = plotOT(dataSet, conf)
+            if len(text_OT):
+                text = text + text_OT
+            else:
+                text = text[:-1]
     else:
             text = text[:-1]
     return text


### PR DESCRIPTION
In cases where the overshooting top feature is present but its lat/lon positions are masked, plotOT() returns an empty string. If this is the case then a trailing comma should be removed from the list of features before it is returned.

Fix for trailing comma issue: https://github.com/cemac/ADAGUC-utilities/issues/2